### PR TITLE
Fix notebook encoding and minor tweaks

### DIFF
--- a/kaggle-solution.ipynb
+++ b/kaggle-solution.ipynb
@@ -159,7 +159,7 @@
     "        return env, iter_test\n",
     "\n",
     "    def get_train_data():\n",
-    "        dataset = load_dataset(config.validation_set, split=\"train[:10]\")\n",
+    "        dataset = load_dataset(config.validation_set, split=\"train\")\n",
     "        dataset = dataset.map(lambda x: {'answer': str(int(x['answer']) % 1000)})\n",
     "        df = dataset.to_pandas()\n",
     "        return df\n",


### PR DESCRIPTION
This PR does the following:

* Fixes the temp file creation in the REPL to use UTF-8
* Enables one to load any validation set on the Hub via a dataset ID (not just the ones on AI-MO)
* Fixes some minor typos
* Loads the tree algo image from a public repo so we also get it on kaggle